### PR TITLE
Remove global install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue-tel-input",
-  "version": "5.12.0",
+  "version": "5.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vue-tel-input",
-      "version": "5.12.0",
+      "version": "5.12.1",
       "license": "MIT",
       "dependencies": {
         "core-js": "^3.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-tel-input",
-  "version": "5.12.0",
+  "version": "5.12.1",
   "description": "International Telephone Input with Vue",
   "author": "Steven Dao <iamstevendao@gmail.com>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -38,15 +38,4 @@ const plugin = {
   install,
 };
 
-// Auto-install
-let GlobalVue = null;
-if (typeof window !== 'undefined') {
-  GlobalVue = window.Vue;
-} else if (typeof global !== 'undefined') {
-  GlobalVue = global.Vue;
-}
-if (GlobalVue) {
-  GlobalVue.use(plugin);
-}
-
 export default plugin;


### PR DESCRIPTION
Automatic installation breaks the plugin if multiple vue instances are present on the page.

For example a CDN vue instance together with a webpack vue instance 